### PR TITLE
let npm know about the Github repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "redux-queue",
   "version": "0.1.0",
   "description": "Library to handle queued requests with ease in your Redux application",
+  "homepage": "https://github.com/JBlaak/Redux-Queue/",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/JBlaak/Redux-Queue.git"
+  },
   "main": "lib/queue.js",
   "scripts": {
     "prepublish": "babel src --out-dir lib",


### PR DESCRIPTION
This commit will make the [npm profile for this package](https://www.npmjs.com/package/redux-queue) display a link to this Github repository.
